### PR TITLE
Improve conversion by incorporating color and alignment

### DIFF
--- a/src/ttml2ssa.py
+++ b/src/ttml2ssa.py
@@ -203,8 +203,8 @@ class Ttml2Ssa(object):
 
         # Grab <style>s
         # https://www.w3.org/TR/ttml1/#styling-attribute-vocabulary
-        for styles_container in ttml_dom.getElementsByTagName('styling'):
-            for style in styles_container.getElementsByTagName('style'):
+        for styles_container in ttml_dom.getElementsByTagNameNS('*', 'styling'):
+            for style in styles_container.getElementsByTagNameNS('*', 'style'):
                 style_id = getattr(
                     style.attributes.get('xml:id', {}), 'value', None)
                 if not style_id:
@@ -214,8 +214,8 @@ class Ttml2Ssa(object):
                     self._italic_style_ids.append(style_id)
 
         # Grab top regions
-        for layout_container in ttml_dom.getElementsByTagName('layout'):
-            for region in layout_container.getElementsByTagName('region'):
+        for layout_container in ttml_dom.getElementsByTagNameNS('*', 'layout'):
+            for region in layout_container.getElementsByTagNameNS('*', 'region'):
                 region_id = getattr(
                     region.attributes.get('xml:id', {}), 'value', None)
                 if region_id:
@@ -223,7 +223,7 @@ class Ttml2Ssa(object):
                     if region.getAttribute('tts:displayAlign') == 'before':
                         self._top_regions_ids.append(region_id)
                     # Case 2: displayAlign is in layout -> region -> style
-                    for style in region.getElementsByTagName('style'):
+                    for style in region.getElementsByTagNameNS('*', 'style'):
                         if style.getAttribute('tts:displayAlign') == 'before':
                             self._top_regions_ids.append(region_id)
 

--- a/src/ttml2ssa.py
+++ b/src/ttml2ssa.py
@@ -72,6 +72,7 @@ class Ttml2Ssa(object):
         self._top_regions_ids = []
 
         self._allowed_style_attrs = (
+            'backgroundColor',
             'color',
             'fontStyle',
             'fontWeight',
@@ -342,6 +343,13 @@ class Ttml2Ssa(object):
                     inline_color_alpha = Ttml2Ssa._rgba_to_alpha_asshex(rgba)
                     _ass_styles.append('\\1c' + inline_color)
                     _ass_styles.append('\\1a' + inline_color_alpha)
+                inline_bcolor = self._styles[style_attrs['style_id']]['background_color']
+                if inline_bcolor != '':
+                    rgba = Ttml2Ssa._hex_to_rgba(inline_bcolor)
+                    inline_bcolor = Ttml2Ssa._rgba_to_bgr_asshex(rgba)
+                    inline_bcolor_alpha = Ttml2Ssa._rgba_to_alpha_asshex(rgba)
+                    _ass_styles.append('\\3c' + inline_bcolor)
+                    _ass_styles.append('\\3a' + inline_bcolor_alpha)
 
             if node.hasChildNodes():
                 dialogue += self._extract_dialogue(node.childNodes, _styles, _ass_styles)

--- a/src/ttml2ssa.py
+++ b/src/ttml2ssa.py
@@ -287,12 +287,14 @@ class Ttml2Ssa(object):
         return style
 
 
-    def _extract_dialogue(self, nodes, styles=[]):
+    def _extract_dialogue(self, nodes, styles=[], ass_styles=[]):
         """Extract text content and styling attributes from <p> elements.
 
         Args:
             nodes (xml.dom.minidom.Node): List of <p> elements
             styles (list): List of style signifiers that should be
+                applied to each node
+            ass_styles (list): List of ASS style signifiers that should be
                 applied to each node
 
         Return:
@@ -303,6 +305,7 @@ class Ttml2Ssa(object):
 
         for node in nodes:
             _styles = []
+            _ass_styles = []
 
             if node.nodeType == node.TEXT_NODE:
                 format_str = '{}'
@@ -317,6 +320,8 @@ class Ttml2Ssa(object):
                         ot='<{}>'.format(style),
                         f=format_str)
 
+                if ass_styles:
+                    dialogue.append('{' + ''.join(ass_styles) + '}')
                 dialogue.append(format_str.format(text))
 
             elif node.localName == 'br':
@@ -330,9 +335,16 @@ class Ttml2Ssa(object):
                 assoc_italic = style_attrs['style_id'] in self._italic_style_ids
                 if inline_italic or assoc_italic or node.parentNode.getAttribute('style') == 'AmazonDefaultStyle':
                     _styles.append('i')
+                inline_color = self._styles[style_attrs['style_id']]['color']
+                if inline_color != '':
+                    rgba = Ttml2Ssa._hex_to_rgba(inline_color)
+                    inline_color = Ttml2Ssa._rgba_to_bgr_asshex(rgba)
+                    inline_color_alpha = Ttml2Ssa._rgba_to_alpha_asshex(rgba)
+                    _ass_styles.append('\\1c' + inline_color)
+                    _ass_styles.append('\\1a' + inline_color_alpha)
 
             if node.hasChildNodes():
-                dialogue += self._extract_dialogue(node.childNodes, _styles)
+                dialogue += self._extract_dialogue(node.childNodes, _styles, _ass_styles)
 
         return ''.join(dialogue)
 
@@ -736,6 +748,41 @@ class Ttml2Ssa(object):
 
         hex_number = "&H" + format(number, '08x').upper()
         return hex_number
+
+    @staticmethod
+    def _hex_to_rgba(value: str) -> tuple[int, int, int, int]:
+        """Convert a hex RGB(A) string into a RGBA tuple.
+
+        Possible string formats:
+            * ``#RRGGBBAA``
+            * ``#RRGGBB``
+            * ``RRGGBBAA``
+            * ``RRGGBB``
+        """
+        value = value.lstrip('#')
+        lv = len(value)
+
+        if lv == 6:  # RGB
+            r, g, b = tuple(int(value[i:i + 2], base=16) for i in range(0, lv, 2))
+            return (r, g, b, 255)   # Default alpha to 255 (fully opaque)
+        elif lv == 8:  # RGBA
+            r, g, b, a = tuple(int(value[i:i + 2], base=16) for i in range(0, lv, 2))
+            return (r, g, b, a)
+        else:
+            raise ValueError("Invalid hex color format. Must be 6 or 8 characters long.")
+
+    @staticmethod
+    def _rgba_to_bgr_asshex(rgba: tuple[int, int, int, int]) -> str:
+        """Convert RGBA tuple to ASS inline BGR format: ``&HBBGGRR&``"""
+        return f'&H{rgba[2]:02X}{rgba[1]:02X}{rgba[0]:02X}&'
+
+    @staticmethod
+    def _rgba_to_alpha_asshex(rgba: tuple[int, int, int, int]) -> str:
+        """Convert RGBA tuple to ASS inline alpha format: ``&HAA&``"""
+
+        # ASS transparency values are inverse to the usual values
+        # with 255 being fully transparent and 0 being fully opaque.
+        return f'&H{255 - rgba[3]:02X}&'
 
     @staticmethod
     def _snake_to_camel(s):

--- a/src/ttml2ssa.py
+++ b/src/ttml2ssa.py
@@ -41,8 +41,6 @@ class Ttml2Ssa(object):
         'FILM2PAL' : 24/25
     }
 
-    TOP_MARKER = '{\\an8}'
-
     def __init__(self, shift=0, source_fps=23.976, scale_factor=1, subtitle_language=None):
         self.shift = shift
         self.source_fps = source_fps
@@ -76,6 +74,7 @@ class Ttml2Ssa(object):
             'color',
             'fontStyle',
             'fontWeight',
+            'textAlign',
         )
 
         ## This variable stores the language ID from the xml file.
@@ -367,14 +366,31 @@ class Ttml2Ssa(object):
                 begin in ms,
                 end in ms,
                 text content in Subrip (SRT) format,
-                position (top or bottom) where the text should appear
+                position (1..9) where the text should appear
         """
 
         begin = paragraph.attributes['begin'].value
         end = paragraph.attributes['end'].value
 
+        style = None
+        if 'style' in paragraph.attributes:
+            style = paragraph.attributes['style'].value
+
         ms_begin = self._tc.timeexpr_to_ms(begin)
         ms_end = self._tc.timeexpr_to_ms(end)
+
+        alignment = None
+        if style and 'text_align' in self._styles[style]:
+            alignment = self._styles[style]['text_align']
+
+        if alignment and alignment == 'center':
+            alignment = 0
+        elif alignment and alignment == 'left':
+            alignment = -1
+        elif alignment and alignment == 'right':
+            alignment = 1
+        else:
+            alignment = 0
 
         dialogue = self._extract_dialogue(paragraph.childNodes)
 
@@ -387,7 +403,10 @@ class Ttml2Ssa(object):
                 new_text += line
         dialogue = new_text
 
-        position = 'top' if paragraph.getAttribute('region') in self._top_regions_ids else 'bottom'
+        # Region information is stored in a numpad layout with numbers 1 to 9
+        # 1 is the lower left and 9 is the upper right corner
+        position = 8 if paragraph.getAttribute('region') in self._top_regions_ids else 2
+        position += alignment
 
         return ms_begin, ms_end, dialogue, position
 
@@ -440,7 +459,7 @@ class Ttml2Ssa(object):
                 entry = {}
                 entry['ms_begin'] = self._tc.timeexpr_to_ms(time1)
                 entry['ms_end'] = self._tc.timeexpr_to_ms(time2)
-                entry['position'] = 'top' if m.group('pos') and float(m.group('pos')) < 50 else 'bottom'
+                entry['position'] = 8 if m.group('pos') and float(m.group('pos')) < 50 else 2
                 text = ""
                 while i < len(lines):
                     line = lines[i].strip()
@@ -473,8 +492,10 @@ class Ttml2Ssa(object):
             # Remove <c> </c> tags
             text = re.sub('</??c.*?>', '', text)
 
-            if self.allow_top_pos and entry['position'] == 'top':
-                text = Ttml2Ssa.TOP_MARKER + text
+            position = entry['position']
+            if not self.allow_top_pos and entry['position'] > 6:
+                position = position - 6
+            text = '{\\an' + str(position) + '}' + text
 
             res += srt_format_str.format(entry_count, \
                                          self._tc.ms_to_subrip(entry['ms_begin']), \
@@ -499,7 +520,7 @@ class Ttml2Ssa(object):
             text = re.sub('</??c.*?>', '', text)
 
             pos_str = 'line:90%,end'
-            if self.allow_top_pos and entry['position'] == 'top':
+            if self.allow_top_pos and entry['position'] > 6:
                 pos_str = 'line:10%,start'
 
             res += vtt_format_str.format(self._tc.ms_to_subrip(entry['ms_begin']).replace(',','.'), \
@@ -536,8 +557,10 @@ class Ttml2Ssa(object):
                         ('<.*?>', '')]:
                 text = re.sub(tag[0], tag[1], text)
 
-            if self.allow_top_pos and entry['position'] == 'top':
-                text = Ttml2Ssa.TOP_MARKER + text
+            position = entry['position']
+            if not self.allow_top_pos and entry['position'] > 6:
+                position = position - 6
+            text = '{\\an' + str(position) + '}' + text
 
             res += ssa_format_str.format(self._tc.ms_to_ssa(entry['ms_begin']), self._tc.ms_to_ssa(entry['ms_end']), text)
         return res


### PR DESCRIPTION
These changes are tailored towards subtitle files coming from the German televisions (ARD, NDR, ZDF, ZDF Neo, ORF, …) being converted into the ASS format. I do hope they're not breaking any other test cases, but I have no way to verify that.

---

The first commit is a fix finding the position styles. They are behind a namespace in my test files which are now correctly found. Notice the `style`, `styling`, `region` and `layout` tags being prefixed with the namespace `tt` in the following very common header.

<details>
<summary>Example header</summary>

~~~ xml
  <tt:head>
    <tt:metadata>
      <ebuttm:documentMetadata>
        <ebuttm:documentEbuttVersion>v1.0</ebuttm:documentEbuttVersion>
      </ebuttm:documentMetadata>
    </tt:metadata>
    <tt:styling>
      <tt:style xml:id="defaultStyle" tts:fontFamily="Verdana,Arial,Tiresias" tts:fontSize="160%" tts:lineHeight="125%" />
      <tt:style xml:id="textBlack" tts:color="#000000" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textRed" tts:color="#FF0000" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textGreen" tts:color="#00FF00" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textYellow" tts:color="#FFFF00" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textBlue" tts:color="#0000FF" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textMagenta" tts:color="#FF00FF" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textCyan" tts:color="#00FFFF" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textWhite" tts:color="#FFFFFF" tts:backgroundColor="#000000c2" />
      <tt:style xml:id="textCenter" tts:textAlign="center" />
      <tt:style xml:id="textLeft" tts:textAlign="left" />
      <tt:style xml:id="textRight" tts:textAlign="right" />
    </tt:styling>
    <tt:layout>
      <tt:region xml:id="top" tts:origin="10% 10%" tts:extent="80% 80%" tts:displayAlign="before" />
      <tt:region xml:id="bottom" tts:origin="10% 10%" tts:extent="80% 80%" tts:displayAlign="after" />
    </tt:layout>
  </tt:head>
~~~

</details>

---

The next two commits are reading the color values for both foreground and background and assigning the values to inline modifiers.

<details>
<summary>Details</summary>

~~~ xml
      <tt:p xml:id="sub1" style="textCenter" region="top" begin="00:00:01.680" end="00:00:04.480">
        <tt:span style="textYellow">Wie ist Hélène so?</tt:span>
        <tt:br />
        <tt:span style="textGreen">Fragen Sie Villanelle.</tt:span>
      </tt:p>
~~~

~~~ ass
Dialogue: 0,0:00:01.76,0:00:04.40,Default,,0,0,0,,{\an8}{\1c&H00FFFF&\1a&H00&\3c&H000000&\3a&H3D&}Wie ist Hélène so?\N{\1c&H00FF00&\1a&H00&\3c&H000000&\3a&H3D&}Fragen Sie Villanelle.
~~~

![grafik](https://github.com/user-attachments/assets/de15f7a0-3490-4b46-a78e-10dc56a3b6a0)

</details>

---

The last commit makes use of the rarely used `textAlign` tag. Those allow shifting text to either side away from the center while still being at the same height. To make calculations easier, I changed the current format of the position (`top`|`bottom`) into the ASS format (`8`|`2`). This allows to subtract or add `1` and have the correct positioning on screen regarding the ASS numpad layout (1..9).

<details>
<summary>Details</summary>

In this example, the `tt:p` is manually edited to feature the `style="textLeft"` tag. The header is the same as in the first example above.

~~~ xml
      <tt:p xml:id="sub3" style="textLeft" region="bottom" begin="00:00:06.360" end="00:00:09.240">
        <tt:span style="textCyan">Ich bin nicht so beschissen,</tt:span>
        <tt:br />
        <tt:span style="textCyan">wie manche denken.</tt:span>
      </tt:p>
~~~

~~~ ass
Dialogue: 0,0:00:06.44,0:00:09.16,Default,,0,0,0,,{\an1}{\1c&HFFFF00&\1a&H00&\3c&H000000&\3a&H3D&}Ich bin nicht so beschissen,\N{\1c&HFFFF00&\1a&H00&\3c&H000000&\3a&H3D&}wie manche denken.
~~~

![grafik](https://github.com/user-attachments/assets/3b98a003-6e57-42a9-acee-bab6e86c423d)

</details>